### PR TITLE
[iOS] Update permissions flow for iOS 11 UIImagePickerController

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -205,6 +205,21 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
     else { // RNImagePickerTargetLibrarySingleImage
         // Wrapper for permission check and showing picker
         void (^showPickerViewControllerIfPermitted)() = ^() {
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
+            if (@available(iOS 11.0, *)) {
+                // iOS 11 no longer requires permission to access single image
+                showPickerViewController();
+            } else {
+                [self checkPhotosPermissions:^(BOOL granted) {
+                    if (!granted) {
+                        self.callback(@[@{@"error": @"Photo library permissions not granted"}]);
+                        return;
+                    }
+                    
+                    showPickerViewController();
+                }];
+            }
+#else
             [self checkPhotosPermissions:^(BOOL granted) {
                 if (!granted) {
                     self.callback(@[@{@"error": @"Photo library permissions not granted"}]);
@@ -213,17 +228,10 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
                 
                 showPickerViewController();
             }];
-        };
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
-        if (@available(iOS 11.0, *)) {
-            // iOS 11 no longer requires permission to access single image
-            showPickerViewController();
-        } else {
-            showPickerViewControllerIfPermitted();
-        }
-#else
-        showPickerViewControllerIfPermitted();
 #endif
+        };
+
+        showPickerViewControllerIfPermitted();
     }
 }
 

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -214,7 +214,7 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
                 showPickerViewController();
             }];
         };
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
         if (@available(iOS 11.0, *)) {
             // iOS 11 no longer requires permission to access single image
             showPickerViewController();

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -203,35 +203,19 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
         }];
     }
     else { // RNImagePickerTargetLibrarySingleImage
-        // Wrapper for permission check and showing picker
-        void (^showPickerViewControllerIfPermitted)() = ^() {
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
-            if (@available(iOS 11.0, *)) {
-                // iOS 11 no longer requires permission to access single image
-                showPickerViewController();
-            } else {
-                [self checkPhotosPermissions:^(BOOL granted) {
-                    if (!granted) {
-                        self.callback(@[@{@"error": @"Photo library permissions not granted"}]);
-                        return;
-                    }
-                    
-                    showPickerViewController();
-                }];
-            }
-#else
+        if (@available(iOS 11.0, *)) {
+            // iOS 11 no longer requires permission to access single image
+            showPickerViewController();
+        } else {
             [self checkPhotosPermissions:^(BOOL granted) {
                 if (!granted) {
                     self.callback(@[@{@"error": @"Photo library permissions not granted"}]);
                     return;
                 }
-                
+
                 showPickerViewController();
             }];
-#endif
         };
-
-        showPickerViewControllerIfPermitted();
     }
 }
 

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -203,14 +203,27 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
         }];
     }
     else { // RNImagePickerTargetLibrarySingleImage
-        [self checkPhotosPermissions:^(BOOL granted) {
-            if (!granted) {
-                self.callback(@[@{@"error": @"Photo library permissions not granted"}]);
-                return;
-            }
-
+        // Wrapper for permission check and showing picker
+        void (^showPickerViewControllerIfPermitted)() = ^() {
+            [self checkPhotosPermissions:^(BOOL granted) {
+                if (!granted) {
+                    self.callback(@[@{@"error": @"Photo library permissions not granted"}]);
+                    return;
+                }
+                
+                showPickerViewController();
+            }];
+        };
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0
+        if (@available(iOS 11.0, *)) {
+            // iOS 11 no longer requires permission to access single image
             showPickerViewController();
-        }];
+        } else {
+            showPickerViewControllerIfPermitted();
+        }
+#else
+        showPickerViewControllerIfPermitted();
+#endif
     }
 }
 


### PR DESCRIPTION
- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

Fixes #818 which explains in more detail the rationale behind this change

## Test Plan (required)

### On pre-iOS 11 devices

#### Scenario 1
1. Launch image picker via `Select a Photo` and tap `Choose from Library...`
2. Verify the permissions prompt appears as normal
3. Ensure that tapping "Ok" lets you access Photos as per normal

#### Scenario 2
1. Launch image picker via `Select a Photo` and tap `Choose from Library...`
2. Verify the permissions  prompt appears as normal
3. Ensure that tapping "Cancel" does not let you access Photos

### On iOS 11 and up devices

1. Launch image picker via `Select a Photo` and tap `Choose from Library...`
2. Verify no permissions prompt appears
3. Ensure that selecting a Photo works as normal

### Xcode Versions

Ensure that the compiler macros work for both Xcode 9 (which has iOS 11 SDK) and all others below.


