### PR TITLE
Add tintColour option for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ permissionDenied.title | - | OK | Title of explaining permissions dialog. By def
 permissionDenied.text | - | OK | Message of explaining permissions dialog. By default `To be able to take pictures with your camera and choose images from your library.`.
 permissionDenied.reTryTitle | - | OK | Title of re-try button. By default `re-try`
 permissionDenied.okTitle | - | OK | Title of ok button. By default `I'm sure`
+tintColor | OK | - | default is `blue`
 
 ### The Response Object
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -41,6 +41,7 @@ declare module "react-native-image-picker" {
         allowsEditing?: boolean;
         noData?: boolean;
         storageOptions?: StorageOptions;
+        tintColor?: string;
     }
 
     interface StorageOptions {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { NativeModules } = require('react-native');
+const { NativeModules, processColor } = require('react-native');
 const { ImagePickerManager } = NativeModules;
 
 const DEFAULT_OPTIONS = {
@@ -15,7 +15,8 @@ const DEFAULT_OPTIONS = {
     text: 'To be able to take pictures with your camera and choose images from your library.',
     reTryTitle: 're-try',
     okTitle: 'I\'m sure',
-  }
+  },
+  tintColor: processColor('blue'),
 };
 
 module.exports = {
@@ -25,6 +26,13 @@ module.exports = {
       callback = options;
       options = {};
     }
-    return ImagePickerManager.showImagePicker({...DEFAULT_OPTIONS, ...options}, callback)
+    return ImagePickerManager.showImagePicker(
+      {
+        ...DEFAULT_OPTIONS,
+        ...options,
+        tintColor: processColor(options.tintColor)
+      },
+      callback
+    )
   }
 }

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -4,6 +4,7 @@
 #import <AVFoundation/AVFoundation.h>
 #import <Photos/Photos.h>
 #import <React/RCTUtils.h>
+#import <React/RCTConvert.h>
 
 @import MobileCoreServices;
 
@@ -49,6 +50,7 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
 
 
     self.alertController = [UIAlertController alertControllerWithTitle:title message:nil preferredStyle:UIAlertControllerStyleActionSheet];
+    self.alertController.view.tintColor = [RCTConvert UIColor:options[@"tintColor"]];
 
     UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:cancelTitle style:UIAlertActionStyleCancel handler:^(UIAlertAction * action) {
         self.callback(@[@{@"didCancel": @YES}]); // Return callback for 'cancel' action (if is required)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-image-picker",
   "description": "A React Native module that allows you to use native UI to select media from the device library or directly from the camera",
-  "version": "0.26.7",
+  "version": "0.26.8",
   "main": "index.js",
   "repository": {
     "type": "git",
@@ -21,6 +21,10 @@
     {
       "name": "Alexander Ustinov",
       "email": "rusfearuth@gmail.com"
+    },
+    {
+      "name": "Ryan Nickel",
+      "email": "ryan@ryannickel.com"
     }
   ],
   "keywords": [


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation

Submitting a PR in order to allow specifying the tintColour for iOS buttons as requested [here](https://github.com/react-community/react-native-image-picker/issues/337) and [here](https://github.com/react-community/react-native-image-picker/issues/114)

## Test Plan

In order to verify that this works:

```
const options = {
      title: '',
      storageOptions: {
        skipBackup: true,
        path: 'images',
      },
      tintColor: 'purple',
    }
ImagePicker.showImagePicker(options, (response: any) => {
   // use response here.
})
```

And you should see text colour changed as:

![tintcolor](https://user-images.githubusercontent.com/495165/43152704-41a75d12-8f3d-11e8-8d12-6e430e9e6258.png)


[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
