### PR TITLE
Add support for Android Studios 3.0.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.+'
+        classpath 'com.android.tools.build:gradle:2+'
     }
 }
 


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [X] Explain the **motivation** for making this change.
- [X] Provide a **test plan** demonstrating that the code is solid.
- [X] Match the **code formatting** of the rest of the codebase.
- [X] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)
Allow users to use Android Studios Gradle Plugin 3.0.0 

What existing problem does the pull request solve?
In order to use this library in projects that use the 3.0.0 gradle plugin, they have to do a manual change in the node_modules each time.

## Test Plan (required)
You are required to have a copy of Gradle 3.0.0 on your machine, then attempt to build an app that contains react-native-image-picker. Run the react-native run-android command... that's it.
