### PR TITLE
#972: change ImageConfig.withOriginalFile() to address testOnImmutable failure

### DIFF
--- a/android/src/main/java/com/imagepicker/media/ImageConfig.java
+++ b/android/src/main/java/com/imagepicker/media/ImageConfig.java
@@ -78,11 +78,13 @@ public class ImageConfig
 
     public @NonNull ImageConfig withOriginalFile(@Nullable final File original)
     {
-        //if it is a GIF file, always set quality to 100 to prevent compression
-        String extension = MimeTypeMap.getFileExtensionFromUrl(original.getAbsolutePath());
-        int quality = this.quality;
-        if(extension.contains("gif")){
-            quality = 100;
+        if (original != null) {
+            //if it is a GIF file, always set quality to 100 to prevent compression
+            String extension = MimeTypeMap.getFileExtensionFromUrl(original.getAbsolutePath());
+            int quality = this.quality;
+            if(extension.contains("gif")){
+                quality = 100;
+            }
         }
 
         return new ImageConfig(


### PR DESCRIPTION


Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

See #972 . testOnImmutable fails due to NPE, and the test failure prevents `./gradle build` or `./gradle assembleRelease` from completing.

## Test Plan (required)

Previously failing test:
![before](https://user-images.githubusercontent.com/16248601/48104377-4711e580-e201-11e8-8cb0-0022be3290f8.png)

Test passes after change:
![after](https://user-images.githubusercontent.com/16248601/48104395-542ed480-e201-11e8-9e4c-55809462a0e0.png)

The only downside I can think of is that if a user were to somehow inadvertently pass a null argument to `withOriginalFile()` it would go uncaught, but the @Nullable annotation and `testOnImmutable()` seem to suggest that this is intentional.


