### PR TITLE
Remove crashing invocation of “stringValue” on iOS

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -244,7 +244,7 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
             if (imageURL && [[imageURL absoluteString] rangeOfString:@"ext=GIF"].location != NSNotFound) {
                 fileName = [tempFileName stringByAppendingString:@".gif"];
             }
-            else if ([[[self.options objectForKey:@"imageFileType"] stringValue] isEqualToString:@"png"]) {
+            else if ([[self.options objectForKey:@"imageFileType"] isEqualToString:@"png"]) {
                 fileName = [tempFileName stringByAppendingString:@".png"];
             }
             else {
@@ -362,7 +362,7 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
             editedImage = [self downscaleImageIfNecessary:editedImage maxWidth:maxWidth maxHeight:maxHeight];
 
             NSData *data;
-            if ([[[self.options objectForKey:@"imageFileType"] stringValue] isEqualToString:@"png"]) {
+            if ([[self.options objectForKey:@"imageFileType"] isEqualToString:@"png"]) {
                 data = UIImagePNGRepresentation(editedImage);
             }
             else {


### PR DESCRIPTION
## Motivation (required)

I need to use `imageFileType` option in order to convert HEIC images to PNG. However, the invocation of `stringValue` crash, since `imageFileType` is already a string.

## Test Plan (required)
With `imageFileType` set to `png`
- [ ] HEIC images are returned as png when selected

With `imageFileType` not set
- [ ] HEIC images are returned as HEIC when selected
