### PR TITLE
Fix iOS build warning

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -13,7 +13,8 @@
 @property (nonatomic, strong) UIImagePickerController *picker;
 @property (nonatomic, strong) RCTResponseSenderBlock callback;
 @property (nonatomic, strong) NSDictionary *defaultOptions;
-@property (nonatomic, retain) NSMutableDictionary *options, *response;
+@property (nonatomic, retain) NSDictionary *options;
+@property (nonatomic, retain) NSMutableDictionary *response;
 @property (nonatomic, strong) NSArray *customButtons;
 
 @end


### PR DESCRIPTION
## Motivation (required)

Fix a warning regarding assignment of `NSDictionary` (options) to `NSMutableDictionary` (self.options).

## Test Plan (required)

I don't think it requires tests...