### PR TITLE
Fix failure delivering result info #579

### DIFF
--- a/android/src/main/java/com/imagepicker/utils/MediaUtils.java
+++ b/android/src/main/java/com/imagepicker/utils/MediaUtils.java
@@ -102,7 +102,7 @@ public class MediaUtils
 
         if (photo == null)
         {
-            return null;
+            return imageConfig;
         }
 
         ImageConfig result = imageConfig;


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [ ] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

On several devices when trying to decode and resize the image (see #579), it will failed and return null value for image configuration. This patch will fix this behavior, instead of returning null value when failed to resize the image, use the original image configuration.

## Test Plan (required)

TODO