### PR TITLE
Export the interfaces in TypeScript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 declare module "react-native-image-picker" {
 
-    interface Response {
+    interface ImagePickerResponse {
         customButton: string;
         didCancel: boolean;
         error: string;
@@ -19,17 +19,17 @@ declare module "react-native-image-picker" {
         timestamp?: string;
     }
 
-    interface CustomButtonOptions {
+    interface ImagePickerCustomButtonOptions {
         name?: string;
         title?: string;
     }
 
-    interface Options {
+    interface ImagePickerOptions {
         title?: string;
         cancelButtonTitle?: string;
         takePhotoButtonTitle?: string;
         chooseFromLibraryButtonTitle?: string;
-        customButtons?: Array<CustomButtonOptions>;
+        customButtons?: Array<ImagePickerCustomButtonOptions>;
         cameraType?: 'front' | 'back';
         mediaType?: 'photo' | 'video' | 'mixed';
         maxWidth?: number;
@@ -40,10 +40,10 @@ declare module "react-native-image-picker" {
         rotation?: number;
         allowsEditing?: boolean;
         noData?: boolean;
-        storageOptions?: StorageOptions;
+        storageOptions?: ImagePickerStorageOptions;
     }
 
-    interface StorageOptions {
+    interface ImagePickerStorageOptions {
         skipBackup?: boolean;
         path?: string;
         cameraRoll?: boolean;
@@ -51,12 +51,10 @@ declare module "react-native-image-picker" {
     }
 
 
-    class ImagePicker {
-        static showImagePicker(options: Options, callback: (response: Response) => void): void;
-        static launchCamera(options: Options, callback: (response: Response) => void): void;
-        static launchImageLibrary(options: Options, callback: (response: Response) => void): void;
+    export default class ImagePicker {
+        static showImagePicker(options: ImagePickerOptions, callback: (response: ImagePickerResponse) => void): void;
+        static launchCamera(options: ImagePickerOptions, callback: (response: ImagePickerResponse) => void): void;
+        static launchImageLibrary(options: ImagePickerOptions, callback: (response: ImagePickerResponse) => void): void;
     }
-
-    export = ImagePicker;
 
 }


### PR DESCRIPTION
## Motivation
This allows users of the library to get access to the types that the library uses to annotate their code. For example, it allows this pattern:

```javascript
import ImagePicker, { ImagePickerOptions } from "react-native-image-picker";

const options: ImagePickerOptions = {
  noData: true
};
ImagePicker.openImagePicker(options);
```

I have also added the `ImagePicker` prefix to the interfaces to make it easier to distinguish them from other `Options` interfaces.

## Test Plan
This can be tested by using the library with TypeScript and using the new types. I have tested this manually on my machine by modifying the type definitions in the `node_modules/react-native-image-picker/index.d.ts` file.