### PR TITLE
[Android] Fix font color for "Take Photo" and "Choose from Library" b…

### DIFF
--- a/android/src/main/res/layout/list_item.xml
+++ b/android/src/main/res/layout/list_item.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:textAppearance="?android:attr/textAppearanceMedium"
-    android:textColor="?android:attr/textColorAlertDialogListItem"
+    android:textColor="#61c3e7"
     android:gravity="center_vertical"
     android:paddingTop="15dp"
     android:paddingBottom="15dp"


### PR DESCRIPTION
…uttons

Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

What existing problem does the pull request solve?
On Android devices the font color of the "Take Photo" and "Choose from Library" buttons is white, matching with the background.

![Screenshot_2019-04-04-18-04-21](https://user-images.githubusercontent.com/25733901/55596935-80934200-5708-11e9-901f-fafbfcf5ac09.png)


## Test Plan (required)

Here is what the component looks like with the fixed font color:

![Screenshot_2019-04-04-18-05-46](https://user-images.githubusercontent.com/25733901/55597025-c6e8a100-5708-11e9-9a91-9266a4137a3d.png)


[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
