### PR TITLE
Update index.js.flow

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -62,5 +62,5 @@ declare export function launchImageLibrary(callback: (response: Response) => any
 declare export default {
   showImagePicker(options: ?Options, callback: (response: Response) => any): void,
   launchCamera(options: ?Options, callback: (response: Response) => any): void,
-  launchImageLibrary(callback: (response: Response) => any): void,
+  launchImageLibrary(options: ?Options, callback: (response: Response) => any): void,
 };


### PR DESCRIPTION
Fix flow error on launchImageLibrary.

## Motivation (required)

It causes a flow error like below:

> Cannot call ImagePicker.launchImageLibrary because no more than 1 argument is expected by function type [1].
> Cannot call ImagePicker.launchImageLibrary with object literal bound to callback because a callable signature is missing
in object literal [1] but exists in function type [2].

## Test Plan (required)

```
import ImagePicker, { type Response } from 'react-native-image-picker';

function launchImageLibrary() {
  ImagePicker.launchImageLibrary({}, (response: Response) => {})
}
```

and then run flow.