### PR TITLE
improved build gradle script

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*]
+charset=utf-8
+end_of_line=lf
+insert_final_newline=false
+indent_style=space
+indent_size=2

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,9 +1,26 @@
 import groovy.json.JsonSlurper
+import java.nio.file.Files
 
+/** Get file of the project */
+static File fileOfProject(prj, filePath) {
+    final projectDir = prj.projectDir
+    final resolvedDir = Files.isSymbolicLink(projectDir.toPath())
+        ? Files.readSymbolicLink(projectDir.toPath())
+        : projectDir.toPath()
+
+    return new File("${resolvedDir}", filePath)
+}
+
+/** Extract property from rootProject if defined, otherwise use fallback value */
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
+/** Extract library version from `package.json` file */
 def computeVersionName() {
     // dynamically retrieve version from package.json
     def slurper = new JsonSlurper()
-    def json = slurper.parse(file('../package.json'), "utf-8")
+    def json = slurper.parse(fileOfProject(project,'../package.json'), "utf-8")
     return json.version
 }
 
@@ -20,26 +37,28 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
-def DEFAULT_COMPILE_SDK_VERSION = 27
-def DEFAULT_BUILD_TOOLS_VERSION = "27.0.3"
-def DEFAULT_TARGET_SDK_VERSION = 26
-
 android {
-    compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
-    buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
+    compileSdkVersion safeExtGet('compileSdkVersion', 27)
+    buildToolsVersion safeExtGet('buildToolsVersion', '27.0.3')
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 26)
+
         versionCode 1
         versionName computeVersionName()
     }
     lintOptions {
         abortOnError false
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 repositories {
+    jcenter()
     mavenCentral()
     google()
     maven {
@@ -51,7 +70,8 @@ repositories {
 }
 
 dependencies {
-    implementation "com.facebook.react:react-native:+"  // From node_modules
+    //noinspection GradleDynamicVersion
+    api "com.facebook.react:react-native:+"  // From node_modules
 
     testImplementation "junit:junit:4.10"
     testImplementation "org.assertj:assertj-core:1.7.0"


### PR DESCRIPTION
- extraction of rootProject properties (according to latest codestyle of RN)
- support of symbolic links as a project directory (live re-mapping of directory structures)

## Motivation (required)

https://github.com/react-native-community/react-native-image-picker/issues/1081

## Test Plan (required)

- connect RN module to your application
- create inside android folder sub-folder `modules`
- create symbolic link to `modules/react-native-image-picker` -> `react-native-image-picker/android`
- add the dependency in an android app project `settings.gradle` as `include ':modules:react-native-image-picker'`
- try to compile the project.

Expected: compilation should pass.
Unexpected: compilation failed with JsonSlupper exception - `can not resolve package.json file path`
