### PR TITLE
Copy file instead of move

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -456,8 +456,14 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
 
                 if (videoURL) { // Protect against reported crash
                   NSError *error = nil;
-                  // iOS 13 b2 may not allow write access to tmp on a trimmed video clip
-                  [fileManager copyItemAtURL:videoURL toURL:videoDestinationURL error:&error];
+
+                  // If we have write access to the source file, move it. Otherwise use copy. 
+                  if ([fileManager isWritableFileAtPath:[videoURL path]]) {
+                    [fileManager moveItemAtURL:videoURL toURL:videoDestinationURL error:&error];
+                  } else {
+                    [fileManager copyItemAtURL:videoURL toURL:videoDestinationURL error:&error];
+                  }
+    
                   if (error) {
                       self.callback(@[@{@"error": error.localizedFailureReason}]);
                       return;

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -456,7 +456,8 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
 
                 if (videoURL) { // Protect against reported crash
                   NSError *error = nil;
-                  [fileManager moveItemAtURL:videoURL toURL:videoDestinationURL error:&error];
+                  // iOS 13 b2 may not allow write access to tmp on a trimmed video clip
+                  [fileManager copyItemAtURL:videoURL toURL:videoDestinationURL error:&error];
                   if (error) {
                       self.callback(@[@{@"error": error.localizedFailureReason}]);
                       return;


### PR DESCRIPTION
iOS 13 beta is not allowing the `moveItemAtURL` command to execute which may cause trimmed clips to fail based on permission.

Instead of moving the file, copy it.

Thanks for submitting a PR! Please read these instructions carefully:

## Motivation (required)
Attempting to access a trimmed video clip on device is failing based on permissions for iOS 13 beta.

What existing problem does the pull request solve?
Instead of affecting the source file with a `move`, instead `copy` it.

## Test Plan (required)

To test, select a video clip from the library that was been trimmed on an iPhone running iOS 13 beta or greater.

An example fetch in JS could be: 
```
    async showImagePicker () {
      ImagePicker.showImagePicker({
        mediaType: 'video',
        noData: true,
        permissionDenied: {
          text: 'To choose and change profile and survey imagery.'
        },
        title: 'Select media',
        durationLimit: 30,
        allowsEditing: true
      }, async (response) => {
        if (response.didCancel || response.error) {
          console.log('response error: ' + response.error)
          return
        }
        console.log('response.uri: ' + response.uri)
      })
    }
```
