### PR TITLE
iOS doesn't need permissions for picking a single image

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -204,7 +204,18 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
         }];
     }
     else { // RNImagePickerTargetLibrarySingleImage
-        showPickerViewController();
+        if ([[[UIDevice currentDevice] systemVersion] floatValue] < 11) {
+            [self checkPhotosPermissions:^(BOOL granted) {
+                if (!granted) {
+                    self.callback(@[@{@"error": @"Photo library permissions not granted"}]);
+                    return;
+                }
+
+                showPickerViewController();
+            }];
+        } else {
+          showPickerViewController();
+        }
     }
 }
 

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -204,14 +204,7 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
         }];
     }
     else { // RNImagePickerTargetLibrarySingleImage
-        [self checkPhotosPermissions:^(BOOL granted) {
-            if (!granted) {
-                self.callback(@[@{@"error": @"Photo library permissions not granted"}]);
-                return;
-            }
-
-            showPickerViewController();
-        }];
+        showPickerViewController();
     }
 }
 


### PR DESCRIPTION
- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)
iOS doesn't need permissions for picking a single image. See more https://stackoverflow.com/a/46594741.

We currently have an issue with this library, that if we want to select a single image, we need to bother the user with it, which is unnecessary. 

## Test Plan (required)

Permissions are notoriously hard to test, so this is something that needs to be done manually.