### PR TITLE
Update react-native-image-picker.podspec

### DIFF
--- a/react-native-image-picker.podspec
+++ b/react-native-image-picker.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.homepage     = package['homepage']
   s.platform     = :ios, "7.0"
 
-  s.source       = { :git => "https://github.com/react-native-community/react-native-image-picker.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/react-native-community/react-native-image-picker.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/*.{h,m}"
 
   s.dependency 'React'


### PR DESCRIPTION
fix pod install

Cloning into '/var/folders/db/ywc4ccn105ld2lp7s1wr_7v40000gn/T/d20190821-12834-1mw2mly'...
warning: Could not find remote branch 1.0.2 to clone.
fatal: Remote branch 1.0.2 not found in upstream origin

Thanks for submitting a PR! Please read these instructions carefully:

- [ ] Explain the **motivation** for making this change.
- [ ] Provide a **test plan** demonstrating that the code is solid.
- [ ] Match the **code formatting** of the rest of the codebase.
- [ ] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

What existing problem does the pull request solve?

## Test Plan (required)

A good test plan has the exact commands you ran and their output, provides screenshots or videos if the pull request changes UI or updates the website. See [What is a Test Plan?][1] to learn more.  

If you have added code that should be tested, add tests.

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
