### PR TITLE
FIX - Issue #1252 - User is presented with permission request after callback has been executed

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -204,18 +204,18 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
         }];
     }
     else { // RNImagePickerTargetLibrarySingleImage
-        if ([[[UIDevice currentDevice] systemVersion] floatValue] < 11) {
-            [self checkPhotosPermissions:^(BOOL granted) {
-                if (!granted) {
-                    self.callback(@[@{@"error": @"Photo library permissions not granted"}]);
-                    return;
-                }
+      if (@available(iOS 11.0, *)) {
+        showPickerViewController();
+      } else {
+        [self checkPhotosPermissions:^(BOOL granted) {
+          if (!granted) {
+            self.callback(@[@{@"error": @"Photo library permissions not granted"}]);
+            return;
+          }
 
-                showPickerViewController();
-            }];
-        } else {
           showPickerViewController();
-        }
+        }];
+      }
     }
 }
 
@@ -301,7 +301,13 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
             }
 
             if (imageURL) {
-                PHAsset *pickedAsset = [PHAsset fetchAssetsWithALAssetURLs:@[imageURL] options:nil].lastObject;
+                PHAsset *pickedAsset;
+                if (@available(iOS 11.0, *)) {
+                  pickedAsset = [info objectForKey: UIImagePickerControllerPHAsset];
+                } else {
+                  pickedAsset = [PHAsset fetchAssetsWithALAssetURLs:@[imageURL] options:nil].lastObject;
+                }
+                
                 NSString *originalFilename = [self originalFilenameForAsset:pickedAsset assetType:PHAssetResourceTypePhoto];
                 self.response[@"fileName"] = originalFilename ?: [NSNull null];
                 if (pickedAsset.location) {


### PR DESCRIPTION
## Motivation

Fixes an issue present on iOS where the user is presented with a dialog requesting permission to view their images. The issue here is that `fetchAssetsWithALAssetURLS:options` requires the users permission. However, this method has been deprecated for quite some time. So, in this PR, I am pulling the `PHAsset` reference from the provided `info` dictionary that is passed into `didFinishPickingMediaWithInfo:`.

If the target is not running iOS 11 or later, I fall back to the old method of gathering permissions and using Photo Kit.

## Test Plan

On devices running iOS 11 or later, users are not presented with a dialog requesting permissions.

![rnImagePicker-IOS13](https://user-images.githubusercontent.com/48732367/72764383-749c4200-3bad-11ea-9cbd-b6495778a1ab.gif)

On devices running iOS 10 or earlier, users will be presented with a system dialog requesting permissions to view images stored on their device.

![rnImagePicker-IOS10](https://user-images.githubusercontent.com/48732367/72764418-a1505980-3bad-11ea-8df0-afafd724a29f.gif)

