### PR TITLE
Fix for bug causing null file type on android (#1176)

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -742,19 +742,25 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
   private void putExtraFileInfo(@NonNull final String path,
                                 @NonNull final ResponseHelper responseHelper)
   {
-    // size && filename
     try {
+      // size && filename
       File f = new File(path);
       responseHelper.putDouble("fileSize", f.length());
       responseHelper.putString("fileName", f.getName());
+      // type
+      String extension = MimeTypeMap.getFileExtensionFromUrl(path);
+      String fileName = f.getName();
+      if (extension != "") {
+        responseHelper.putString("type", MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension));
+      } else {
+        int i = fileName.lastIndexOf('.');
+        if (i > 0) {
+          extension = fileName.substring(i+1);
+          responseHelper.putString("type", MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension));
+        }
+      }
     } catch (Exception e) {
       e.printStackTrace();
-    }
-
-    // type
-    String extension = MimeTypeMap.getFileExtensionFromUrl(path);
-    if (extension != null) {
-      responseHelper.putString("type", MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension));
     }
   }
 


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [ x] Explain the **motivation** for making this change.
- [ x] Provide a **test plan** demonstrating that the code is solid.
- [ x] Match the **code formatting** of the rest of the codebase.
- [x ] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

When picking images on android, files with names that have a space in them cause the response.type to be null. This bug causes the image attachment process to unexpectedly fail. These code changes were proposed in #1176 but haven't been placed in a pull request.

## Test Plan (required)

I have tested this change on an S7. Using the original version, I received a null response file type when choosing an image that has a space in its name, and after these changes, I received the correct file type. I tested it on several other jpeg/png photos and had no problems with either on this S7 or the iPhone 11 simulator. 