### PR TITLE
Add write permission check when accessing camera android

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -583,7 +583,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
         permissionsGranted = writePermission == PackageManager.PERMISSION_GRANTED;
         break;
       case REQUEST_PERMISSIONS_FOR_CAMERA:
-        permissionsGranted = cameraPermission == PackageManager.PERMISSION_GRANTED;
+        permissionsGranted = cameraPermission == PackageManager.PERMISSION_GRANTED && writePermission == PackageManager.PERMISSION_GRANTED;
         break;
     }
 
@@ -641,13 +641,13 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
             PERMISSIONS = new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE};
             break;
           case REQUEST_PERMISSIONS_FOR_CAMERA:
-            PERMISSIONS = new String[]{Manifest.permission.CAMERA};
+            PERMISSIONS = new String[]{Manifest.permission.CAMERA,Manifest.permission.WRITE_EXTERNAL_STORAGE};
             break;
           default:
             PERMISSIONS = new String[]{};
             break;
         }
-        
+
         if (activity instanceof ReactActivity)
         {
           ((ReactActivity) activity).requestPermissions(PERMISSIONS, requestCode, listener);


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [X] Explain the **motivation** for making this change.
- [X] Provide a **test plan** demonstrating that the code is solid.
- [X] Match the **code formatting** of the rest of the codebase.
- [X] Target the `master` branch, NOT a "stable" branch.

## Motivation

When accessing the camera for the first time only permission for the camera is requested.
This results in that the camera won't open on Android. 
The permission for writing to external storage is also required to launch the camera.
Related issues: #1286 #1290

## Test Plan (required)
Since there is no functional changes no new tests where added. All existing tests passes. 
