### PR TITLE
test: Make tests work with >=Java9 by upgrading libraries

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,6 +30,12 @@ android {
     lintOptions {
         abortOnError false
     }
+
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
 }
 
 repositories {
@@ -47,13 +53,13 @@ repositories {
 dependencies {
     api "com.facebook.react:react-native:+"  // From node_modules
 
-    testImplementation "junit:junit:4.10"
-    testImplementation "org.assertj:assertj-core:1.7.0"
-    testImplementation "org.robolectric:robolectric:3.3.2"
+    testImplementation('org.robolectric:robolectric:4.3.1') {
+        // https://github.com/robolectric/robolectric/issues/5245
+        exclude group: 'com.google.auto.service', module: 'auto-service'
+    }
 
-    testImplementation "org.easytesting:fest-assert-core:${FEST_ASSERT_CORE_VERSION}"
     testImplementation "org.powermock:powermock-api-mockito:${POWERMOCK_VERSION}"
+    testImplementation "org.powermock:powermock-module-junit4:${POWERMOCK_VERSION}"
     testImplementation "org.powermock:powermock-module-junit4-rule:${POWERMOCK_VERSION}"
     testImplementation "org.powermock:powermock-classloading-xstream:${POWERMOCK_VERSION}"
-    testImplementation "org.mockito:mockito-core:${MOCKITO_CORE_VERSION}"
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,6 +1,4 @@
-MOCKITO_CORE_VERSION=1.+
-POWERMOCK_VERSION=1.6.2
-FEST_ASSERT_CORE_VERSION=2.0M10
+POWERMOCK_VERSION=1.6.6
 
 ReactNativeImagePicker_compileSdkVersion=28
 ReactNativeImagePicker_buildToolsVersion=28.0.3
@@ -9,3 +7,4 @@ ReactNativeImagePicker_minSdkVersion=16
 
 android.useAndroidX=true
 android.enableJetifier=true
+android.enableUnitTestBinaryResources=true

--- a/android/src/test/java/com/imagepicker/testing/ImagePickerModuleTest.java
+++ b/android/src/test/java/com/imagepicker/testing/ImagePickerModuleTest.java
@@ -45,8 +45,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @RunWith(RobolectricTestRunner.class)
 @SuppressStaticInitializationFor("com.facebook.react.common.build.ReactBuildConfig")
 @PrepareForTest({Arguments.class})
-@PowerMockIgnore({"org.mockito.*", "org.robolectric.*", "android.*"})
-@Config(manifest = Config.NONE)
+@PowerMockIgnore({"org.mockito.*", "org.robolectric.*", "android.*", "jdk.internal.reflect.*"})
 public class ImagePickerModuleTest
 {
     private static final int DEFAULT_THEME = R.style.DefaultExplainingPermissionsTheme;


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

With Java 9 (and later) the unit tests fails with:
`java.lang.ClassCastException: class jdk.internal.loader.ClassLoaders$AppClassLoader cannot be cast to class java.net.URLClassLoader`.

Issue has been solved by upgrading RoboElectric and related test libraries.

Related issues #1121 #1142 

## Test Plan (required)

Existing android unit tests are still working, executed with Java 10.
