### PR TITLE
Set robolectric's url of maven repositories to https

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,6 +30,11 @@ android {
     lintOptions {
         abortOnError false
     }
+    testOptions {
+        unitTests.all {
+            systemProperty 'robolectric.dependency.repo.url', 'https://repo1.maven.org/maven2'
+        }
+    }
 }
 
 repositories {


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [X] Explain the **motivation** for making this change.
- [X] Provide a **test plan** demonstrating that the code is solid.
- [X] Match the **code formatting** of the rest of the codebase.
- [X] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

Tests in my project were failing due with error:
```
Unable to resolve artifact: Unable to get dependency information: Unable to read the metadata file for artifact 'org.robolectric:android-all:jar': Cannot find parent: org.sonatype.oss:oss-parent for project: org.robolectric:android-all:jar:4.1.2_r1-robolectric-0 for project org.robolectric:android-all:jar:4.1.2_r1-robolectric-0
  org.robolectric:android-all:jar:4.1.2_r1-robolectric-0

from the specified remote repositories:
  central (http://repo1.maven.org/maven2),
  sonatype (https://oss.sonatype.org/content/groups/public/)
```
After investigation I found out The Central Repository requires `https` (source: https://support.sonatype.com/hc/en-us/articles/360041287334 ).
I implemented fix proposed on this isssue: https://github.com/robolectric/robolectric/issues/1536

## Test Plan (required)

Unit tests are now working for me
