### PR TITLE
remove deprecated gradle option

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -7,4 +7,3 @@ ReactNativeImagePicker_minSdkVersion=16
 
 android.useAndroidX=true
 android.enableJetifier=true
-android.enableUnitTestBinaryResources=true


### PR DESCRIPTION
remove The option 'android.enableUnitTestBinaryResources' is deprecated
which is removed from gradle 6, The current default is 'false'
to allow the build using gradle 6
