### PR TITLE
Fix wrong package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To use this library you need to ensure you match up with the correct version of 
 
 p.s. React Native introduced AndroidX support in 0.60, which is a **breaking change** for most libraries (incl. this one) using native Android functionality.
 
-| `@react-native-community/imagepicker` version | Required React Native Version                                                     |
+| `react-native-image-picker` version | Required React Native Version                                                     |
 | ----------------------------------------- | --------------------------------------------------------------------------------- |
 | `1.x.x`                                   | `>= 0.60` or `>= 0.59` if using [Jetifier](https://github.com/mikehardy/jetifier) |
 | `0.x.x`                                   | `<= 0.59`                                                                         |


### PR DESCRIPTION
## Motivation

Fixes the non-existent package name in `README.md` which is misleading and can sometimes be confusing.
